### PR TITLE
Fixed file saving error caused by string concatenation

### DIFF
--- a/iptcinfo3.py
+++ b/iptcinfo3.py
@@ -687,7 +687,7 @@ class IPTCInfo:
         else:
             tmpfh.close()
             if os.path.exists(newfile):
-                shutil.move(newfile, newfile + '~')
+                shutil.move(newfile, "{file}~".format(file=newfile))
             shutil.move(tmpfn, newfile)
         return True
 


### PR DESCRIPTION
Replaced `+` concatenation with `.format()`.

Used to throw the following traceback on Windows when trying to save a file:
```
Traceback (most recent call last):
  File "C:\Users\Angius\PycharmProjects\fbmangler\venv\lib\site-packages\iptcinfo3.py", line 627, in save
    return self.save_as(self._filename, options)
  File "C:\Users\Angius\PycharmProjects\fbmangler\venv\lib\site-packages\iptcinfo3.py", line 690, in save_as
    shutil.move(newfile, newfile + '~')
TypeError: unsupported operand type(s) for +: 'WindowsPath' and 'str'
```