### PR TITLE
Add 'in' operator support to IPTCInfo and IPTCData

### DIFF
--- a/iptcinfo3.py
+++ b/iptcinfo3.py
@@ -553,6 +553,13 @@ class IPTCData(dict):
         else:
             raise KeyError("Key %s is not in %s!" % (key, list(c_datasets.keys())))
 
+    def __contains__(self, name):
+        try:
+            key = self._key_as_int(name)
+        except KeyError:
+            return False
+        return super().__contains__(key)
+
     def __getitem__(self, name):
         return self.get(self._key_as_int(name), None)
 
@@ -698,6 +705,9 @@ class IPTCInfo:
 
     def __len__(self):
         return len(self._data)
+
+    def __contains__(self, key):
+        return key in self._data
 
     def __getitem__(self, key):
         return self._data[key]

--- a/iptcinfo_test.py
+++ b/iptcinfo_test.py
@@ -48,6 +48,9 @@ def test_IPTCData():
     assert data[105].startswith('Audiobook')
     assert data['Headline'].startswith('Audiobook')
 
+    assert 'headline' in data
+    assert 105 in data
+
     data['keywords'] = ['foo']
     data['keywords'] = ['foo', 'bar']
     with pytest.raises(ValueError):
@@ -59,10 +62,16 @@ def test_IPTCData():
     with pytest.raises(KeyError):
         data['yobby'] = 'yoshi'
 
+    assert 'yobby' not in data
+    assert 9999 not in data
+
     data = IPTCData({'nonstandard_69': 'sanic'})
     assert data[69] == 'sanic'
 
     assert str(data) == "{'nonstandard_69': 'sanic'}"
+
+    assert 69 in data
+    assert 'nonstandard_69' in data
 
 
 def test_file_is_jpeg_detects_invalid_file():
@@ -81,6 +90,8 @@ def test_getitem_can_read_info():
     assert info['supplemental category'] == [b'supplemental category']
     assert info['caption/abstract'] == b'I am a caption'
 
+    assert 'keywords' in info
+    assert 'nonexistent' not in info
 
 def test_save_as_saves_as_new_file_with_info():
     if os.path.isfile('fixtures/deleteme.jpg'):  # pragma: no cover


### PR DESCRIPTION
So we can do
```python
info = IPTCInfo('foo.jpg')
if 'caption/abstract' in info:
```
etc.

Many thanks