### PR TITLE
Added an overwrite keyword

### DIFF
--- a/iptcinfo3.py
+++ b/iptcinfo3.py
@@ -693,7 +693,9 @@ class IPTCInfo:
             os.unlink(tmpfn)
         else:
             tmpfh.close()
-            if os.path.exists(newfile):
+            if os.path.exists(newfile) and options is not None and 'overwrite' in options:
+                os.unlink(newfile)
+            elif os.path.exists(newfile):
                 shutil.move(newfile, "{file}~".format(file=newfile))
             shutil.move(tmpfn, newfile)
         return True


### PR DESCRIPTION
If a user passes `overwrite` as an option to the `save` or `save_as` function, the existing file is overwritten. If no keyword is passed, the current method remains in place (i.e. adding a `~` to the original filename).
This can solve issue #22.